### PR TITLE
Respond to only messages and ignore Update(edited_message)

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -126,7 +126,7 @@ def is_group(update: Update) -> bool:
 def is_reply(update: Update) -> bool:
     return (
         is_group(update)
-        and update.effective_message.reply_to_message.from_user.is_bot
+        and update.message is not None and update.message.reply_to_message.from_user.is_bot
     )
 
 


### PR DESCRIPTION
According to the [docs][1], `effective_message` casts multiple types of update in to one type for a catch-all purpose.

Since in this case, we specifically need to ignore the update of kind `edited_message` and rest of the update types are irrelevant anyway.


[1]: https://docs.python-telegram-bot.org/en/stable/telegram.update.html#telegram.Update.effective_message