### PR TITLE
Optimize Docker image size be cleaning up cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8.10-alpine
 
 COPY . /edgegpt
 WORKDIR /edgegpt
-RUN apk add build-base
-RUN pip install wheel
-RUN pip install -r requirements.txt
+RUN apk add --no-cache build-base
+RUN pip install --no-cache-dir wheel
+RUN pip install --no-cache-dir -r requirements.txt
 CMD ["python", "src/edge.py"]


### PR DESCRIPTION
Size change:

```
REPOSITORY              TAG                  IMAGE ID       CREATED              SIZE
after                   latest               77d6ceea5e8e   About a minute ago   359MB
before                  latest               43a1d5ccc6cb   About a minute ago   413MB
```
